### PR TITLE
feat: Implement multi-task time tracking

### DIFF
--- a/app/api/timer/route.ts
+++ b/app/api/timer/route.ts
@@ -4,12 +4,12 @@ import type { StartTimerRequest, StopTimerRequest } from '@/lib/types';
 
 export async function GET() {
   try {
-    const activeEntry = timerUtils.getActive();
-    return NextResponse.json(activeEntry);
+    const activeEntries = timerUtils.getActive();
+    return NextResponse.json(activeEntries);
   } catch (error) {
-    console.error('Error fetching active timer:', error);
+    console.error('Error fetching active timers:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch active timer' },
+      { error: 'Failed to fetch active timers' },
       { status: 500 }
     );
   }

--- a/components/TasksClient.tsx
+++ b/components/TasksClient.tsx
@@ -27,7 +27,7 @@ export default function TasksClient({ initialTasks, project }: { initialTasks: T
   const [tasks, setTasks] = useState<Task[]>(initialTasks);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
-  const { activeTimer, startTimer, stopTimer } = useTimer();
+  const { activeTimers, startTimer, stopTimer } = useTimer();
 
   const handleFormSubmit = (task: Task) => {
     if (selectedTask) {
@@ -87,24 +87,28 @@ export default function TasksClient({ initialTasks, project }: { initialTasks: T
             </TableRow>
           </TableHeader>
           <TableBody>
-            {tasks.map((task) => (
-              <TableRow key={task.id}>
-                <TableCell>{task.name}</TableCell>
-                <TableCell>{task.status}</TableCell>
-                <TableCell>{formatDuration(task.total_duration || 0)}</TableCell>
-                <TableCell className="text-right">
-                  {activeTimer && activeTimer.task_id === task.id ? (
-                    <Button variant="ghost" size="icon" onClick={() => handleStopTimer(activeTimer.id)}>
-                      <Square className="h-4 w-4 text-red-500" />
-                    </Button>
-                  ) : (
-                    <Button variant="ghost" size="icon" onClick={() => handleStartTimer(task)}>
-                      <Play className="h-4 w-4" />
-                    </Button>
-                  )}
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" className="h-8 w-8 p-0">
+            {tasks.map((task) => {
+              const activeTimerForTask = activeTimers.find(
+                (timer) => timer.task_id === task.id
+              );
+              return (
+                <TableRow key={task.id}>
+                  <TableCell>{task.name}</TableCell>
+                  <TableCell>{task.status}</TableCell>
+                  <TableCell>{formatDuration(task.total_duration || 0)}</TableCell>
+                  <TableCell className="text-right">
+                    {activeTimerForTask ? (
+                      <Button variant="ghost" size="icon" onClick={() => handleStopTimer(activeTimerForTask.id)}>
+                        <Square className="h-4 w-4 text-red-500" />
+                      </Button>
+                    ) : (
+                      <Button variant="ghost" size="icon" onClick={() => handleStartTimer(task)}>
+                        <Play className="h-4 w-4" />
+                      </Button>
+                    )}
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" className="h-8 w-8 p-0">
                         <span className="sr-only">Open menu</span>
                         <MoreHorizontal className="h-4 w-4" />
                       </Button>
@@ -124,8 +128,9 @@ export default function TasksClient({ initialTasks, project }: { initialTasks: T
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </TableCell>
-              </TableRow>
-            ))}
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       </div>

--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,3 @@
+
+> time-tracker-v1@0.1.0 dev
+> next dev --turbopack

--- a/hooks/useTimer.ts
+++ b/hooks/useTimer.ts
@@ -4,17 +4,17 @@ import { useState, useEffect } from 'react';
 import { TimeEntry } from '@/lib/types';
 
 export function useTimer() {
-  const [activeTimer, setActiveTimer] = useState<TimeEntry | null>(null);
+  const [activeTimers, setActiveTimers] = useState<TimeEntry[]>([]);
 
   useEffect(() => {
-    const fetchActiveTimer = async () => {
+    const fetchActiveTimers = async () => {
       const response = await fetch('/api/timer');
       const data = await response.json();
       if (response.ok) {
-        setActiveTimer(data);
+        setActiveTimers(data);
       }
     };
-    fetchActiveTimer();
+    fetchActiveTimers();
   }, []);
 
   const startTimer = async (task_id: number) => {
@@ -23,9 +23,9 @@ export function useTimer() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ task_id }),
     });
-    const data = await response.json();
+    const newTimer = await response.json();
     if (response.ok) {
-      setActiveTimer(data);
+      setActiveTimers((prev) => [...prev, newTimer]);
     }
   };
 
@@ -36,9 +36,9 @@ export function useTimer() {
       body: JSON.stringify({ time_entry_id }),
     });
     if (response.ok) {
-      setActiveTimer(null);
+      setActiveTimers((prev) => prev.filter((timer) => timer.id !== time_entry_id));
     }
   };
 
-  return { activeTimer, startTimer, stopTimer };
+  return { activeTimers, startTimer, stopTimer };
 }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -162,14 +162,13 @@ export const queries = {
     ORDER BY te.start_time DESC
   `),
   
-  getActiveTimeEntry: db.prepare(`
+  getActiveTimeEntries: db.prepare(`
     SELECT te.*, t.name as task_name, p.name as project_name
     FROM time_entries te
     JOIN tasks t ON te.task_id = t.id
     JOIN projects p ON t.project_id = p.id
     WHERE te.end_time IS NULL
     ORDER BY te.start_time DESC
-    LIMIT 1
   `),
   
   updateTimeEntry: db.prepare(`

--- a/lib/db-utils.ts
+++ b/lib/db-utils.ts
@@ -124,8 +124,8 @@ export const timeEntryUtils = {
     ) as TimeEntry[];
   },
 
-  getActive: (): TimeEntry | null => {
-    return queries.getActiveTimeEntry.get() as TimeEntry | null;
+  getActive: (): TimeEntry[] => {
+    return queries.getActiveTimeEntries.all() as TimeEntry[];
   },
 
   update: (id: number, data: UpdateTimeEntryRequest): TimeEntry | null => {
@@ -171,12 +171,6 @@ export const timeEntryUtils = {
 // Timer utilities
 export const timerUtils = {
   start: (data: StartTimerRequest): TimeEntry => {
-    // Stop any active timer first
-    const activeEntry = timeEntryUtils.getActive();
-    if (activeEntry) {
-      timeEntryUtils.stop(activeEntry.id);
-    }
-
     const startTime = new Date().toISOString();
     return timeEntryUtils.create({
       task_id: data.task_id,
@@ -189,7 +183,7 @@ export const timerUtils = {
     return timeEntryUtils.stop(data.time_entry_id);
   },
 
-  getActive: (): TimeEntry | null => {
+  getActive: (): TimeEntry[] => {
     return timeEntryUtils.getActive();
   }
 };


### PR DESCRIPTION
This commit refactors the time tracking functionality to allow users to start, stop, and track multiple tasks simultaneously.

The key changes include:
- The backend API at `/api/timer` has been updated to handle multiple active time entries.
- The `useTimer` hook now manages an array of active timers.
- The `TasksClient` component has been updated to display and manage multiple running timers in the UI.
- The database query for fetching active timers has been modified to return all active entries instead of just one.
- The logic that stopped a running timer when a new one was started has been removed.